### PR TITLE
Fix the way orig_data is set during an external clean.

### DIFF
--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -417,7 +417,7 @@ class MongoReference(Field):
             raise ValidationError('Object does not exist.')
 
 class Schema(object):
-    def __init__(self, raw_data=None, data=None, orig_data=None):
+    def __init__(self, raw_data=None, data=None, **kwargs):
         conflicting_fields = set([
             'raw_data', 'orig_data', 'data', 'errors', 'field_errors', 'fields'
         ]).intersection(dir(self))
@@ -426,7 +426,12 @@ class Schema(object):
                 'Please use the field_name keyword to use them.' % list(conflicting_fields))
 
         self.raw_data = raw_data or {}
-        self.orig_data = orig_data or data or None
+
+        if 'orig_data' in kwargs:
+            self.orig_data = kwargs['orig_data']
+        else:
+            self.orig_data = data or None
+
         self.data = data and dict(data) or {}
         self.field_errors = {}
         self.errors = []

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -465,12 +465,7 @@ class Schema(object):
                 'Please use the field_name keyword to use them.' % list(conflicting_fields))
 
         self.raw_data = raw_data or {}
-
-        if 'orig_data' in kwargs:
-            self.orig_data = kwargs['orig_data']
-        else:
-            self.orig_data = data or None
-
+        self.orig_data = data or None
         self.data = data and dict(data) or {}
         self.field_errors = {}
         self.errors = []

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -432,11 +432,25 @@ class Schema(object):
 
     2. Create a Schema instance, passing data into it.
 
+        # Scenario 1: Creation of a new object.
         schema = UserSchema({
             'first_name': 'Donald',
             'last_name': 'Glover',
             'email': 'gambino@example.com'
         })
+
+        # Scenario 2: Update of an existing object.
+        schema = UserSchema(
+            raw_data={
+                'first_name': 'Childish',
+                'last_name': 'Gambino'
+            },
+            data={
+                'first_name': 'Donald',
+                'last_name': 'Glover',
+                'email': 'gambino@example.com'
+            }
+        )
 
     3. Clean the Schema (validating the data you passed into it).
 

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -417,7 +417,46 @@ class MongoReference(Field):
             raise ValidationError('Object does not exist.')
 
 class Schema(object):
-    def __init__(self, raw_data=None, data=None, **kwargs):
+    """
+    Base Schema class. Provides core behavior like fields declaration
+    and construction, validation, and data and error proxying.
+
+    There are 3 steps to using a Schema:
+
+    1. Define the Schema, e.g.
+
+        class UserSchema(Schema):
+            first_name = String()
+            last_name = String()
+            email = Email()
+
+    2. Create a Schema instance, passing data into it.
+
+        schema = UserSchema({
+            'first_name': 'Donald',
+            'last_name': 'Glover',
+            'email': 'gambino@example.com'
+        })
+
+    3. Clean the Schema (validating the data you passed into it).
+
+        data = schema.full_clean()
+
+    This operation will raise a ValidationError if the data you passed
+    into the Schema is invalid.
+
+    To introduce custom validation to the Schema (beyond the basics
+    covered by various Field types), override the "clean" method and
+    raise a ValidationError with a descriptive message if you encounter
+    any invalid data.
+
+    Parameters:
+    - raw_data - a dict with the data you want to validate.
+    - data - dict with existing data, e.g. based on some object you're
+             trying to update.
+    """
+
+    def __init__(self, raw_data=None, data=None):
         conflicting_fields = set([
             'raw_data', 'orig_data', 'data', 'errors', 'field_errors', 'fields'
         ]).intersection(dir(self))

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -495,13 +495,14 @@ class Schema(object):
 
     def external_clean(self, cls, raise_on_errors=True):
         try:
-            self.data.update(
-                cls(
-                    raw_data=self.raw_data,
-                    data=self.data,
-                    orig_data=self.orig_data
-                ).full_clean()
-            )
+            # Instantiate the external schema with the right raw_data/data.
+            external_schema = cls(raw_data=self.raw_data, data=self.data)
+
+            # Make sure its orig_data is the same as this schema's
+            external_schema.orig_data = self.orig_data
+
+            # Validate the schema and update self.data with its results.
+            self.data.update(external_schema.full_clean())
         except ValidationError as e:
             self.field_errors.update(e.args[0]['field-errors'])
             self.errors += e.args[0]['errors']

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -467,11 +467,8 @@ class ExternalCleanTestCase(unittest.TestCase):
             schema.full_clean()
             self.assertFalse(True)  # we should never get here
         except ValidationError as e:
-            self.assertEqual(e.message, {
-                'errors': [],
-                'field-errors': {
-                    'status': "Can't change from sent to inbox"
-                }
+            self.assertEqual(schema.field_errors, {
+                'status': "Can't change from sent to inbox"
             })
 
     # TODO: Test MongoEmbedded, MongoReference, more Schema tests.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -407,6 +407,10 @@ class FieldTestCase(ValidationTestCase):
 
 
 class ExternalCleanTestCase(unittest.TestCase):
+    """
+    Collection of tests making sure Schema#external_clean works as
+    expected.
+    """
 
     def setUp(self):
 
@@ -421,6 +425,8 @@ class ExternalCleanTestCase(unittest.TestCase):
 
                 if (orig_status == 'sent' and new_status == 'inbox'):
                     self.field_errors['status'] = "Can't change from sent to inbox"
+
+                self.data['message_cleaned'] = True
 
                 return self.data
 
@@ -441,8 +447,18 @@ class ExternalCleanTestCase(unittest.TestCase):
             raw_data={'subject': 'hi', 'status': 'sent'},
         )
         schema.full_clean()
+        self.assertEqual(schema.data, {
+            'subject': 'hi',
+            'status': 'sent',
+            'message_cleaned': True,
+        })
 
     def test_orig_data_in_external_clean(self):
+
+        # Create a schema for an existing object, which originally had
+        # subject='hi' and status='sent' and we're trying to validate an
+        # update to subject='hi updated' and status='inbox' (which shouldn't
+        # be allowed).
         schema = self.EmailSchema(
             raw_data={'subject': 'hi updated', 'status': 'inbox'},
             data={'subject': 'hi', 'status': 'sent'},

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,9 @@
-import unittest
 import datetime
+import unittest
+
 from cleancat import *
 from cleancat.utils import ValidationTestCase
+
 
 class FieldTestCase(ValidationTestCase):
     def test_string(self):
@@ -402,6 +404,59 @@ class FieldTestCase(ValidationTestCase):
         self.assertValid(UnmutableSchema({'text': 'existing'}, {'text': 'existing'}), {'text': 'existing'})
         self.assertValid(UnmutableSchema({}, {'text': 'hello'}), {'text': 'hello'})
         self.assertValid(UnmutableSchema({'text': 'hello'}, {}), {'text': 'hello'})
+
+
+class ExternalCleanTestCase(unittest.TestCase):
+
+    def setUp(self):
+
+        # Generic message schema that may be used in composition with more
+        # specific schemas
+        class MessageSchema(Schema):
+            status = String(required=True)
+
+            def clean(self):
+                orig_status = self.orig_data and self.orig_data['status']
+                new_status = self.data['status']
+
+                if (orig_status == 'sent' and new_status == 'inbox'):
+                    self.field_errors['status'] = "Can't change from sent to inbox"
+
+                return self.data
+
+        # Specific email schema that also calls the generic message schema
+        # via external_clean
+        class EmailSchema(Schema):
+            subject = String()
+
+            def full_clean(self):
+                super(EmailSchema, self).full_clean()
+                self.external_clean(MessageSchema)
+
+        self.MessageSchema = MessageSchema
+        self.EmailSchema = EmailSchema
+
+    def test_external_clean(self):
+        schema = self.EmailSchema(
+            raw_data={'subject': 'hi', 'status': 'sent'},
+        )
+        schema.full_clean()
+
+    def test_orig_data_in_external_clean(self):
+        schema = self.EmailSchema(
+            raw_data={'subject': 'hi updated', 'status': 'inbox'},
+            data={'subject': 'hi', 'status': 'sent'},
+        )
+        try:
+            schema.full_clean()
+            self.assertFalse(True)  # we should never get here
+        except ValidationError as e:
+            self.assertEqual(e.message, {
+                'errors': [],
+                'field-errors': {
+                    'status': "Can't change from sent to inbox"
+                }
+            })
 
     # TODO: Test MongoEmbedded, MongoReference, more Schema tests.
 


### PR DESCRIPTION
I noticed that calling `external_clean(ExtSchema)` from a `BaseSchema` where `self.orig_data is None` results in `ExtSchema.orig_data == BaseSchema.data`, which is wrong and prevents `ExtSchema` for doing proper validation based on original values.

- [x] unit test