### PR TITLE
Add serialization capabilities

### DIFF
--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -162,6 +162,9 @@ class DateTime(Regex):
             return dt
         return dt.date()
 
+    def serialize(self, value):
+        return value.isoformat()
+
 class Email(Regex):
     regex = r'^.+@[^.].*\.[a-z]{2,63}$'
     regex_flags = re.IGNORECASE
@@ -313,6 +316,9 @@ class Embedded(Dict):
             return False
         else:
             return True
+
+    def serialize(self, value):
+        return self.schema_class(data=value).serialize()
 
 class Choices(Field):
     """

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -283,6 +283,9 @@ class List(Field):
 
         return data
 
+    def serialize(self, value):
+        return [self.field_instance.serialize(item) for item in value]
+
 class Dict(Field):
     base_type = dict
 
@@ -427,6 +430,9 @@ class MongoReference(Field):
         except self.document_class.DoesNotExist:
             raise ValidationError('Object does not exist.')
 
+    def serialize(self, value):
+        return value.pk
+
 class Schema(object):
     """
     Base Schema class. Provides core behavior like fields declaration
@@ -504,6 +510,8 @@ class Schema(object):
         for field_name in cls.get_fields():
             if hasattr(obj, field_name):
                 value = getattr(obj, field_name)
+                if callable(value):
+                    value = value()
                 data[field_name] = value
         return data
 

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -315,6 +315,9 @@ class Embedded(Dict):
             return True
 
 class Choices(Field):
+    """
+    A field that accepts the given choices.
+    """
     def __init__(self, choices, case_insensitive=False, error_invalid_choice=None, **kwargs):
         super(Choices, self).__init__(**kwargs)
         self.choices = choices
@@ -344,6 +347,16 @@ class Choices(Field):
             raise ValidationError(self.error_invalid_choice.format(value=value))
 
         return value
+
+class Enum(Choices):
+    """
+    Like Choices, but expects a Python 3 Enum.
+    """
+    def get_choices(self):
+        return [choice.value for choice in self.choices]
+
+    def serialize(self, choice):
+        return choice.value
 
 # TODO move to separate module
 class MongoEmbedded(Embedded):
@@ -378,7 +391,6 @@ class MongoEmbeddedReference(MongoEmbedded):
     def __init__(self, *args, **kwargs):
         self.pk_field = kwargs.pop('pk_field', 'id')
         super(MongoEmbeddedReference, self).__init__(*args, **kwargs)
-
 
     def clean(self, value):
         value = super(Embedded, self).clean(value)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,5 @@
 import datetime
+import sys
 import unittest
 
 from cleancat import *
@@ -261,6 +262,21 @@ class FieldTestCase(ValidationTestCase):
         self.assertValid(CaseInsensitiveChoiceSchema({'choice': 'wOrLd'}), {'choice': 'world'})
         self.assertInvalid(CaseInsensitiveChoiceSchema({'choice': 'world '}), {'field-errors': ['choice']})
         self.assertInvalid(CaseInsensitiveChoiceSchema({'choice': 'invalid'}), {'field-errors': ['choice']})
+
+    @unittest.skipIf(sys.version_info < (3, 4), 'enum unavailable')
+    def test_enum(self):
+        import enum
+
+        class Choices(enum.Enum):
+            A = 'a'
+            B = 'b'
+
+        class ChoiceSchema(Schema):
+            choice = Enum(Choices)
+
+        self.assertValid(ChoiceSchema({'choice': 'a'}), {'choice': 'a'})
+        self.assertValid(ChoiceSchema({'choice': 'b'}), {'choice': 'b'})
+        self.assertInvalid(ChoiceSchema({'choice': 'c'}), {'field-errors': ['choice']})
 
     def test_url(self):
         class URLSchema(Schema):


### PR DESCRIPTION
Add serialization capabilities so that a schema can be used both for validating input data as well as for returning output data.

This allows keeping both the read and write fields in the schema for a cleaner integration with REST libraries.

Also adds an `Enum` field that can be used in Python 3.4+.