### PR TITLE
Support URLs with IDN TLDs

### DIFF
--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -167,7 +167,7 @@ class URL(Regex):
     blank_value = None
 
     def __init__(self, require_tld=True, default_scheme=None, allowed_schemes=None, **kwargs):
-        tld_part = (require_tld and r'\.[a-z]{2,10}' or '')
+        tld_part = (require_tld and r'\.[\w-]{2,24}' or '')
         scheme_part = '[a-z]+://'
         self.default_scheme = default_scheme
         if self.default_scheme and not self.default_scheme.endswith('://'):
@@ -175,8 +175,8 @@ class URL(Regex):
         self.scheme_regex = re.compile('^'+scheme_part, re.IGNORECASE)
         if default_scheme:
             scheme_part = '(%s)?' % scheme_part
-        regex = r'^%s([^/:]+%s|([0-9]{1,3}\.){3}[0-9]{1,3})(:[0-9]+)?(\/.*)?$' % (scheme_part, tld_part)
-        super(URL, self).__init__(regex=regex, regex_flags=re.IGNORECASE, regex_message='Invalid URL.', **kwargs)
+        regex = r'^%s([^/:]+%s|([0-9]{1,3}\.){3}[0-9]{1,3})(:[0-9]+)?([/?].*)?$' % (scheme_part, tld_part)
+        super(URL, self).__init__(regex=regex, regex_flags=re.IGNORECASE | re.UNICODE, regex_message='Invalid URL.', **kwargs)
 
         self.allowed_schemes = allowed_schemes or []
         self.allowed_schemes_regexes = []

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import datetime
 import unittest
 
@@ -268,8 +269,21 @@ class FieldTestCase(ValidationTestCase):
 
         self.assertValid(URLSchema({'url': 'http://example.com/a?b=c'}), {'url': 'http://example.com/a?b=c'})
         self.assertValid(URLSchema({'url': 'ftp://ftp.example.com'}), {'url': 'ftp://ftp.example.com'})
+        self.assertValid(URLSchema({'url': 'http://example.com?params=without&path'}), {'url': 'http://example.com?params=without&path'})
         self.assertInvalid(URLSchema({'url': 'www.example.com'}), {'field-errors': ['url']})
         self.assertInvalid(URLSchema({'url': 'invalid'}), {'field-errors': ['url']})
+
+        # Russian unicode URL (IDN, unicode path and query params)
+        self.assertValid(URLSchema({'url': u'http://пример.com'}), {'url': u'http://пример.com'})
+        self.assertValid(URLSchema({'url': u'http://пример.рф'}), {'url': u'http://пример.рф'})
+        self.assertValid(URLSchema({'url': u'http://пример.рф/путь/?параметр=значение'}), {'url': u'http://пример.рф/путь/?параметр=значение'})
+
+        # Punicode stuff
+        self.assertValid(URLSchema({'url': u'http://test.XN--11B4C3D'}), {'url': u'http://test.XN--11B4C3D'})
+
+        # http://stackoverflow.com/questions/9238640/how-long-can-a-tld-possibly-be
+        # Longest to date (Feb 2017) TLD in punicode format is 24 chars long
+        self.assertValid(URLSchema({'url': u'http://test.xn--vermgensberatung-pwb'}), {'url': u'http://test.xn--vermgensberatung-pwb'})
 
         class DefaultURLSchema(Schema):
             url = URL(default_scheme='http://')


### PR DESCRIPTION
Allow IDN TLDs: accepting basically any unicode alphanumerical TLD, including punicode `http://привет.рф`, `http://xn--b1agh1afp.xn--p1ai` and so on.

Allow URLs with a query string but without a path `http://example.com?params` (note absent slash before `?`).