### PR TITLE
Stricter URL check by not allowing arbitrary chars in domain part

### DIFF
--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -175,7 +175,7 @@ class URL(Regex):
         self.scheme_regex = re.compile('^'+scheme_part, re.IGNORECASE)
         if default_scheme:
             scheme_part = '(%s)?' % scheme_part
-        regex = r'^%s([^/:]+%s|([0-9]{1,3}\.){3}[0-9]{1,3})(:[0-9]+)?([/?].*)?$' % (scheme_part, tld_part)
+        regex = r'^%s([-\w@:%%_+.~#?&/\\=]{2,256}%s|([0-9]{1,3}\.){3}[0-9]{1,3})(:[0-9]+)?([/?].*)?$' % (scheme_part, tld_part)
         super(URL, self).__init__(regex=regex, regex_flags=re.IGNORECASE | re.UNICODE, regex_message='Invalid URL.', **kwargs)
 
         self.allowed_schemes = allowed_schemes or []

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -167,7 +167,12 @@ class URL(Regex):
     blank_value = None
 
     def __init__(self, require_tld=True, default_scheme=None, allowed_schemes=None, **kwargs):
-        tld_part = (require_tld and r'\.[\w-]{2,24}' or '')
+        # FQDN validation similar to https://github.com/chriso/validator.js/blob/master/src/lib/isFQDN.js
+
+        # ff01-ff5f -> full-width chars, not allowed
+        alpha_numeric_and_symbols_ranges = u'0-9a-z\u00a1-\uff00\uff5f-\uffff'
+
+        tld_part = (require_tld and r'\.[%s-]{2,63}' % alpha_numeric_and_symbols_ranges or '')
         scheme_part = '[a-z]+://'
         self.default_scheme = default_scheme
         if self.default_scheme and not self.default_scheme.endswith('://'):
@@ -175,7 +180,7 @@ class URL(Regex):
         self.scheme_regex = re.compile('^'+scheme_part, re.IGNORECASE)
         if default_scheme:
             scheme_part = '(%s)?' % scheme_part
-        regex = r'^%s([-\w@:%%_+.~#?&/\\=]{2,256}%s|([0-9]{1,3}\.){3}[0-9]{1,3})(:[0-9]+)?([/?].*)?$' % (scheme_part, tld_part)
+        regex = r'^%s([-%s@:%%_+.~#?&/\\=]{1,256}%s|([0-9]{1,3}\.){3}[0-9]{1,3})(:[0-9]+)?([/?].*)?$' % (scheme_part, alpha_numeric_and_symbols_ranges, tld_part)
         super(URL, self).__init__(regex=regex, regex_flags=re.IGNORECASE | re.UNICODE, regex_message='Invalid URL.', **kwargs)
 
         self.allowed_schemes = allowed_schemes or []

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -267,13 +267,21 @@ class FieldTestCase(ValidationTestCase):
         class URLSchema(Schema):
             url = URL()
 
+        self.assertValid(URLSchema({'url': 'http://x.com'}), {'url': 'http://x.com'})
+        self.assertValid(URLSchema({'url': u'http://♡.com'}), {'url': u'http://♡.com'})
         self.assertValid(URLSchema({'url': 'http://example.com/a?b=c'}), {'url': 'http://example.com/a?b=c'})
         self.assertValid(URLSchema({'url': 'ftp://ftp.example.com'}), {'url': 'ftp://ftp.example.com'})
         self.assertValid(URLSchema({'url': 'http://example.com?params=without&path'}), {'url': 'http://example.com?params=without&path'})
         self.assertInvalid(URLSchema({'url': 'www.example.com'}), {'field-errors': ['url']})
         self.assertInvalid(URLSchema({'url': 'http:// invalid.com'}), {'field-errors': ['url']})
         self.assertInvalid(URLSchema({'url': 'http://!nvalid.com'}), {'field-errors': ['url']})
+        self.assertInvalid(URLSchema({'url': 'http://.com'}), {'field-errors': ['url']})
+        self.assertInvalid(URLSchema({'url': 'http://'}), {'field-errors': ['url']})
+        self.assertInvalid(URLSchema({'url': 'http://.'}), {'field-errors': ['url']})
         self.assertInvalid(URLSchema({'url': 'invalid'}), {'field-errors': ['url']})
+
+        # full-width chars disallowed
+        self.assertInvalid(URLSchema({'url': u'http://ＧＯＯＧＬＥ.com'}), {'field-errors': ['url']})
 
         # Russian unicode URL (IDN, unicode path and query params)
         self.assertValid(URLSchema({'url': u'http://пример.com'}), {'url': u'http://пример.com'})

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -271,6 +271,8 @@ class FieldTestCase(ValidationTestCase):
         self.assertValid(URLSchema({'url': 'ftp://ftp.example.com'}), {'url': 'ftp://ftp.example.com'})
         self.assertValid(URLSchema({'url': 'http://example.com?params=without&path'}), {'url': 'http://example.com?params=without&path'})
         self.assertInvalid(URLSchema({'url': 'www.example.com'}), {'field-errors': ['url']})
+        self.assertInvalid(URLSchema({'url': 'http:// invalid.com'}), {'field-errors': ['url']})
+        self.assertInvalid(URLSchema({'url': 'http://!nvalid.com'}), {'field-errors': ['url']})
         self.assertInvalid(URLSchema({'url': 'invalid'}), {'field-errors': ['url']})
 
         # Russian unicode URL (IDN, unicode path and query params)
@@ -300,6 +302,9 @@ class FieldTestCase(ValidationTestCase):
         self.assertValid(RelaxedURLSchema({'url': 'http://example.com/a?b=c'}), {'url': 'http://example.com/a?b=c'})
         self.assertValid(RelaxedURLSchema({'url': 'ftp://ftp.example.com'}), {'url': 'ftp://ftp.example.com'})
         self.assertValid(RelaxedURLSchema({'url': 'www.example.com'}), {'url': 'http://www.example.com'})
+        self.assertValid(RelaxedURLSchema({'url': u'http://пример.рф'}), {'url': u'http://пример.рф'})
+        self.assertInvalid(RelaxedURLSchema({'url': 'http:// invalid.com'}), {'field-errors': ['url']})
+        self.assertInvalid(RelaxedURLSchema({'url': 'http://!nvalid.com'}), {'field-errors': ['url']})
         self.assertInvalid(RelaxedURLSchema({'url': 'http://'}), {'field-errors': ['url']})
         self.assertInvalid(RelaxedURLSchema({'url': 'invalid'}), {'field-errors': ['url']})
         self.assertInvalid(RelaxedURLSchema({'url': True}), {'field-errors': ['url']})


### PR DESCRIPTION
Do not allow spaces and other nonsense in domain part.

Ex: `http:// google.com`