### PR TITLE
Return enumeration member in Enum class

### DIFF
--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -366,6 +366,10 @@ class Enum(Choices):
     def get_choices(self):
         return [choice.value for choice in self.choices]
 
+    def clean(self, value):
+        value = super(Enum, self).clean(value)
+        return self.choices(value)
+
     def serialize(self, choice):
         return choice.value
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -298,8 +298,8 @@ class FieldTestCase(ValidationTestCase):
         class ChoiceSchema(Schema):
             choice = Enum(MyChoices)
 
-        self.assertValid(ChoiceSchema({'choice': 'a'}), {'choice': 'a'})
-        self.assertValid(ChoiceSchema({'choice': 'b'}), {'choice': 'b'})
+        self.assertValid(ChoiceSchema({'choice': 'a'}), {'choice': MyChoices.A})
+        self.assertValid(ChoiceSchema({'choice': 'b'}), {'choice': MyChoices.B})
         self.assertInvalid(ChoiceSchema({'choice': 'c'}), {'field-errors': ['choice']})
 
     def test_url(self):


### PR DESCRIPTION
The `Enum` type should return the enumeration member instead of the value. The value is still returned when serializing the data.