### PR TITLE
Use flake8

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 test:
+  pre:
+    - flake8
   override:
     - pyenv global 2.7.11 3.4.4 3.5.1
     - tox

--- a/cleancat/__init__.py
+++ b/cleancat/__init__.py
@@ -1,1 +1,13 @@
-from cleancat.base import *
+from cleancat.base import (
+    Bool, Choices, DateTime, Dict, Email, Embedded, Enum, Field, Integer,
+    List, MongoEmbedded, MongoEmbeddedReference, MongoReference, Regex,
+    RelaxedURL, Schema, SortedSet, StopValidation, String, TrimmedString, URL,
+    ValidationError
+)
+
+__all__ = [
+    'Bool', 'Choices', 'DateTime', 'Dict', 'Email', 'Embedded', 'Enum',
+    'Field', 'Integer', 'List', 'MongoEmbedded', 'MongoEmbeddedReference',
+    'MongoReference', 'Regex', 'RelaxedURL', 'Schema', 'SortedSet',
+    'StopValidation', 'String', 'TrimmedString', 'URL', 'ValidationError'
+]

--- a/cleancat/utils.py
+++ b/cleancat/utils.py
@@ -1,5 +1,7 @@
 import unittest
+
 from cleancat import ValidationError
+
 
 def compare_dict_keys(data, keys, test_true=True):
     if isinstance(keys, list):
@@ -16,15 +18,16 @@ def compare_dict_keys(data, keys, test_true=True):
         else:
             assert k in keys, 'Key %r is unexpected in %r' % (k, data)
 
+
 def compare_req_resp(req_obj, resp_obj):
     for k, v in req_obj.items():
         assert k in resp_obj.keys(), 'Key %r not in response (keys are %r)' % (k, resp_obj.keys())
         assert resp_obj[k] == v, 'Value for key %r should be %r but is %r' % (k, v, resp_obj[k])
 
+
 class ValidationTestCase(unittest.TestCase):
     def assertValid(self, schema, data):
         compare_req_resp(data, schema.full_clean())
-        #self.assertEqual(schema.full_clean(), data)
 
     def assertInvalid(self, schema, error_keys=None, error_obj=None):
         self.assertRaises(ValidationError, schema.full_clean)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+flake8
 python-dateutil
 pytz

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+ignore=E501,F401,F403
+exclude=venv,.tox,.eggs

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
-ignore=E501,F401,F403
+ignore=E501
 exclude=venv,.tox,.eggs,build

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
 ignore=E501,F401,F403
-exclude=venv,.tox,.eggs
+exclude=venv,.tox,.eggs,build


### PR DESCRIPTION
Adds flake8 to the CI and fixes issues discovered by its run. We ignore `E501` because some lines can be longer than 79 chars without that being a problem.

Motivated primarily by the fact that `MongoEmbeddedReference` defined its `clean` method twice :)