### PR TITLE
Clean up MongoEmbeddedReference

### DIFF
--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -404,64 +404,94 @@ class SortedSet(List):
 # TODO move to separate module
 class MongoEmbedded(Embedded):
     """
-    Represents an embedded document. Expects the document contents as input.
-    Example document: EmbeddedDocumentField(Doc)
+    Represents MongoEngine's EmbeddedDocument. Expects the document's
+    contents as an input dict.
     """
     def __init__(self, document_class=None, *args, **kwargs):
         self.document_class = document_class
         super(MongoEmbedded, self).__init__(*args, **kwargs)
 
     def clean(self, value):
+        """Clean the provided dict of values and then return an
+        EmbeddedDocument instantiated with them.
+        """
         value = super(MongoEmbedded, self).clean(value)
         return self.document_class(**value)
 
 
 class MongoEmbeddedReference(MongoEmbedded):
     """
-    Represents a reference. Expects the document contents as input.
-    Example document: ReferenceField(Doc)
+    Represents a MongoEngine document, which can be created or updated based
+    on a provided dict of values.
 
-    The primary key of the related reference can be specified using pk_field.
-    By default, `id` is the pk_field. If the passed document contains the
-    pk_field, it is validated whether a document with that ID exists. If the
-    document does not contain the pk_field, it is assumed that a new document
-    will be created.
+    The name of the field that acts as the primary key of the document can be
+    specified using pk_field (it's 'id' by default). If the passed document
+    contains the pk_field, we check if a document with that PK exists and then
+    we update its fields (or fail if it can't be found). If the input dict
+    does not contain the pk_field, it is assumed that a new document should be
+    created.
 
     Examples:
-    {'id': 'existing_id', 'foo': 'bar'} -> valid
+    {'id': 'existing_id', 'foo': 'bar'} -> valid (updates an existing document)
     {'id': 'non-existing_id', 'foo': 'bar'} -> invalid
-    {'foo': 'bar'} -> valid
+    {'foo': 'bar'} -> valid (creates a new document)
     """
+
     def __init__(self, *args, **kwargs):
         self.pk_field = kwargs.pop('pk_field', 'id')
         super(MongoEmbeddedReference, self).__init__(*args, **kwargs)
 
     def clean(self, value):
-        from mongoengine import ValidationError as MongoValidationError
         if value and self.pk_field in value:
-            try:
-                document = self.document_class.objects.get(pk=value[self.pk_field])
-            except self.document_class.DoesNotExist:
-                raise ValidationError('Object does not exist.')
-            except MongoValidationError as e:
-                raise ValidationError(str(e))
-            else:
-                value = Dict.clean(self, value)
-                if hasattr(document, 'to_dict'):  # support mongomallard
-                    document_data = document.to_dict()
-                else:
-                    document_data = dict(document._data)
-                if None in document_data:
-                    del document_data[None]
-                value = self.schema_class(value, document_data).full_clean()
-                for field_name, field_value in value.items():
-                    if field_name != self.pk_field:
-                        setattr(document, field_name, field_value)
-                return document
+            return self.clean_existing(value)
+        return self.clean_new(value)
+
+    def clean_new(self, value):
+        """Return a new document instantiated with cleaned data."""
+        value = Dict.clean(self, value)
+        value = self.schema_class(value).full_clean()
+        return self.document_class(**value)
+
+    def clean_existing(self, value):
+        """Clean the data and return an existing document with its fields
+        updated based on the cleaned values.
+        """
+        from mongoengine import ValidationError as MongoValidationError
+
+        existing_pk = value[self.pk_field]
+        try:
+            document = self.document_class.objects.get(pk=existing_pk)
+        except self.document_class.DoesNotExist:
+            raise ValidationError('Object does not exist.')
+        except MongoValidationError as e:
+            raise ValidationError(str(e))
+
+        # Validate the value is a dict.
+        # TODO this validation is redundant since this class inherits from
+        # MongoEmbedded, which inherits from Embedded, which inherits from
+        # Dict. Dict's validation is performed before the clean() method is
+        # even called.
+        value = Dict.clean(self, value)
+
+        # Get a dict of existing document's field names and values.
+        if hasattr(document, 'to_dict'):
+            # MongoMallard
+            document_data = document.to_dict()
         else:
-            value = Dict.clean(self, value)
-            value = self.schema_class(value).full_clean()
-            return self.document_class(**value)
+            # Upstream MongoEngine
+            document_data = dict(document._data)
+        if None in document_data:
+            del document_data[None]
+
+        # Clean the data.
+        value = self.schema_class(value, document_data).full_clean()
+
+        # Set cleaned data on the document (except for the pk_field).
+        for field_name, field_value in value.items():
+            if field_name != self.pk_field:
+                setattr(document, field_name, field_value)
+
+        return document
 
 
 class MongoReference(Field):

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -442,13 +442,13 @@ class MongoEmbeddedReference(MongoEmbedded):
         super(MongoEmbeddedReference, self).__init__(*args, **kwargs)
 
     def clean(self, value):
+        value = Dict.clean(self, value)
         if value and self.pk_field in value:
             return self.clean_existing(value)
         return self.clean_new(value)
 
     def clean_new(self, value):
         """Return a new document instantiated with cleaned data."""
-        value = Dict.clean(self, value)
         value = self.schema_class(value).full_clean()
         return self.document_class(**value)
 

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -466,13 +466,6 @@ class MongoEmbeddedReference(MongoEmbedded):
         except MongoValidationError as e:
             raise ValidationError(str(e))
 
-        # Validate the value is a dict.
-        # TODO this validation is redundant since this class inherits from
-        # MongoEmbedded, which inherits from Embedded, which inherits from
-        # Dict. Dict's validation is performed before the clean() method is
-        # even called.
-        value = Dict.clean(self, value)
-
         # Get a dict of existing document's field names and values.
         if hasattr(document, 'to_dict'):
             # MongoMallard
@@ -483,7 +476,8 @@ class MongoEmbeddedReference(MongoEmbedded):
         if None in document_data:
             del document_data[None]
 
-        # Clean the data.
+        # Clean the data (passing the new data dict and the original data to
+        # the schema).
         value = self.schema_class(value, document_data).full_clean()
 
         # Set cleaned data on the document (except for the pk_field).


### PR DESCRIPTION
Commits can be reviewed separately. The first commit introduces no logical changes. The second one fixes a redundant call to `Dict.clean` (I've confirmed that it was called twice for a single POST/PUT in our API).