### PR TITLE
EmbeddedReference base class + SQLAEmbeddedReference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ venv
 # Packages
 *.egg
 *.egg-info
+.eggs
 dist
 build
 eggs

--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,10 @@ develop-eggs
 # Installer logs
 pip-log.txt
 
-# Unit test / coverage reports
+# Unit test / coverage reports and cache
 .coverage
 .tox
+.pytest_cache/
 
 #Translations
 *.mo

--- a/cleancat/__init__.py
+++ b/cleancat/__init__.py
@@ -1,11 +1,12 @@
 from cleancat.base import (
-    Bool, Choices, DateTime, Dict, Email, Embedded, Enum, Field, Integer,
-    List, Regex, RelaxedURL, Schema, SortedSet, StopValidation, String,
-    TrimmedString, URL, ValidationError
+    Bool, Choices, DateTime, Dict, Email, Embedded, EmbeddedReference, Enum,
+    Field, Integer, List, Regex, RelaxedURL, Schema, SortedSet, StopValidation,
+    String, TrimmedString, URL, ValidationError
 )
 
 __all__ = [
-    'Bool', 'Choices', 'DateTime', 'Dict', 'Email', 'Embedded', 'Enum',
-    'Field', 'Integer', 'List', 'Regex', 'RelaxedURL', 'Schema', 'SortedSet',
-    'StopValidation', 'String', 'TrimmedString', 'URL', 'ValidationError'
+    'Bool', 'Choices', 'DateTime', 'Dict', 'Email', 'Embedded',
+    'EmbeddedReference', 'Enum', 'Field', 'Integer', 'List', 'Regex',
+    'RelaxedURL', 'Schema', 'SortedSet', 'StopValidation', 'String',
+    'TrimmedString', 'URL', 'ValidationError'
 ]

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -344,6 +344,10 @@ class Embedded(Dict):
         return self.schema_class(data=value).serialize()
 
 
+class ReferenceNotFoundError(Exception):
+    """Exception to be raised when a referenced object isn't found."""
+
+
 class EmbeddedReference(Dict):
     """Represents an object which can be referenced by its ID.
 
@@ -409,6 +413,7 @@ class EmbeddedReference(Dict):
 
         :param str pk: ID of the object that's supposed to exist.
         :returns: an instance of the object class.
+        :raises: ReferenceNotFoundError if the object doesn't exist.
         """
         raise NotImplementedError  # should be subclassed
 
@@ -613,6 +618,8 @@ class Schema(object):
 
                     self.data[field_name] = value
 
+            except ReferenceNotFoundError:
+                self.field_errors[raw_field_name] = 'Object does not exist.'
             except ValidationError as e:
                 self.field_errors[raw_field_name] = e.args and e.args[0]
             except StopValidation as e:

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -400,6 +400,12 @@ class EmbeddedReference(Dict):
     def get_orig_data_from_existing(self, obj):
         raise NotImplementedError  # should be subclassed
 
+    def serialize(self, obj):
+        obj_data = self.get_orig_data_from_existing(obj)
+        serialized = self.schema_class(data=obj_data).serialize()
+        serialized[self.pk_field] = getattr(obj, self.pk_field)
+        return serialized
+
 
 class Choices(Field):
     """

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -1,13 +1,12 @@
 import datetime
 import re
-import sys
 
 import pytz
+import six
 from dateutil import parser
 
 
-if sys.version_info[0] == 3:
-    basestring = str
+basestring = six.string_types[0]
 
 
 class ValidationError(Exception):
@@ -388,7 +387,7 @@ class EmbeddedReference(Dict):
         value = self.schema_class(value, orig_data).full_clean()
 
         # Set cleaned data on the object (except for the pk_field).
-        for field_name, field_value in value.iteritems():
+        for field_name, field_value in value.items():
             if field_name != self.pk_field:
                 setattr(obj, field_name, field_value)
 

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -392,7 +392,10 @@ class EmbeddedReference(Dict):
         updated based on the cleaned values.
         """
         existing_pk = value[self.pk_field]
-        obj = self.fetch_existing(existing_pk)
+        try:
+            obj = self.fetch_existing(existing_pk)
+        except ReferenceNotFoundError:
+            raise ValidationError('Object does not exist.')
         orig_data = self.get_orig_data_from_existing(obj)
 
         # Clean the data (passing the new data dict and the original data to
@@ -621,8 +624,6 @@ class Schema(object):
 
                     self.data[field_name] = value
 
-            except ReferenceNotFoundError:
-                self.field_errors[raw_field_name] = 'Object does not exist.'
             except ValidationError as e:
                 self.field_errors[raw_field_name] = e.args and e.args[0]
             except StopValidation as e:

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -1,12 +1,15 @@
 import datetime
 import re
+import sys
 
 import pytz
-import six
 from dateutil import parser
 
 
-basestring = six.string_types[0]
+if sys.version_info[0] == 3:
+    str_type = str
+else:
+    str_type = basestring
 
 
 class ValidationError(Exception):
@@ -66,7 +69,7 @@ class Field(object):
 
 
 class String(Field):
-    base_type = basestring
+    base_type = str_type
     blank_value = ''
     min_length = None
     max_length = None
@@ -95,7 +98,7 @@ class String(Field):
 
 
 class TrimmedString(String):
-    base_type = basestring
+    base_type = str_type
     blank_value = ''
 
     def clean(self, value):
@@ -183,7 +186,7 @@ class Email(Regex):
 
     def clean(self, value):
         # trim any leading/trailing whitespace before validating the email
-        if isinstance(value, basestring):
+        if isinstance(value, str_type):
             value = value.strip()
         return super(Email, self).clean(value)
 
@@ -452,7 +455,7 @@ class Choices(Field):
         if self.case_insensitive:
             choices = {choice.lower(): choice for choice in choices}
 
-            if not isinstance(value, basestring):
+            if not isinstance(value, str_type):
                 raise ValidationError(u'Value needs to be a string.')
 
             if value.lower() not in choices:

--- a/cleancat/mongo.py
+++ b/cleancat/mongo.py
@@ -6,7 +6,9 @@ them via `from cleancat.mongo import ...`.
 
 from mongoengine import ValidationError as MongoValidationError
 
-from .base import Embedded, EmbeddedReference, Field, ValidationError
+from .base import (
+    Embedded, EmbeddedReference, Field, ValidationError, basestring
+)
 
 
 class MongoEmbedded(Embedded):

--- a/cleancat/mongo.py
+++ b/cleancat/mongo.py
@@ -6,7 +6,7 @@ them via `from cleancat.mongo import ...`.
 
 from mongoengine import ValidationError as MongoValidationError
 
-from .base import Dict, Embedded, Field, ValidationError
+from .base import Embedded, EmbeddedReference, Field, ValidationError
 
 
 class MongoEmbedded(Embedded):
@@ -26,71 +26,37 @@ class MongoEmbedded(Embedded):
         return self.document_class(**value)
 
 
-class MongoEmbeddedReference(MongoEmbedded):
+class MongoEmbeddedReference(EmbeddedReference):
     """
-    Represents a MongoEngine document, which can be created or updated based
-    on a provided dict of values.
+    Represents an embedded reference where the object class is a MongoEngine
+    document.
 
-    The name of the field that acts as the primary key of the document can be
-    specified using pk_field (it's 'id' by default). If the passed document
-    contains the pk_field, we check if a document with that PK exists and then
-    we update its fields (or fail if it can't be found). If the input dict
-    does not contain the pk_field, it is assumed that a new document should be
-    created.
-
-    Examples:
-    {'id': 'existing_id', 'foo': 'bar'} -> valid (updates an existing document)
-    {'id': 'non-existing_id', 'foo': 'bar'} -> invalid
-    {'foo': 'bar'} -> valid (creates a new document)
+    Examples of passed data and how it's handled:
+    {'id': 'existing_id', 'foo': 'bar'} -> updates an existing document
+    {'id': 'non-existing_id', 'foo': 'bar'} -> fails bcos the PK is not valid
+    {'foo': 'bar'} -> creates a new document instance
     """
 
-    def __init__(self, *args, **kwargs):
-        self.pk_field = kwargs.pop('pk_field', 'id')
-        super(MongoEmbeddedReference, self).__init__(*args, **kwargs)
-
-    def clean(self, value):
-        value = Dict.clean(self, value)
-        if value and self.pk_field in value:
-            return self.clean_existing(value)
-        return self.clean_new(value)
-
-    def clean_new(self, value):
-        """Return a new document instantiated with cleaned data."""
-        value = self.schema_class(value).full_clean()
-        return self.document_class(**value)
-
-    def clean_existing(self, value):
-        """Clean the data and return an existing document with its fields
-        updated based on the cleaned values.
-        """
-        existing_pk = value[self.pk_field]
+    def fetch_existing(self, pk):
+        doc_cls = self.object_class
         try:
-            document = self.document_class.objects.get(pk=existing_pk)
-        except self.document_class.DoesNotExist:
+            return doc_cls.objects.get(pk=pk)
+        except doc_cls.DoesNotExist:
             raise ValidationError('Object does not exist.')
         except MongoValidationError as e:
             raise ValidationError(str(e))
 
+    def get_orig_data_from_existing(self, obj):
         # Get a dict of existing document's field names and values.
-        if hasattr(document, 'to_dict'):
+        if hasattr(obj, 'to_dict'):
             # MongoMallard
-            document_data = document.to_dict()
+            doc_data = obj.to_dict()
         else:
             # Upstream MongoEngine
-            document_data = dict(document._data)
-        if None in document_data:
-            del document_data[None]
-
-        # Clean the data (passing the new data dict and the original data to
-        # the schema).
-        value = self.schema_class(value, document_data).full_clean()
-
-        # Set cleaned data on the document (except for the pk_field).
-        for field_name, field_value in value.items():
-            if field_name != self.pk_field:
-                setattr(document, field_name, field_value)
-
-        return document
+            doc_data = dict(obj._data)
+        if None in doc_data:
+            del doc_data[None]
+        return doc_data
 
 
 class MongoReference(Field):

--- a/cleancat/mongo.py
+++ b/cleancat/mongo.py
@@ -53,13 +53,10 @@ class MongoEmbeddedReference(EmbeddedReference):
         # Get a dict of existing document's field names and values.
         if hasattr(obj, 'to_dict'):
             # MongoMallard
-            doc_data = obj.to_dict()
+            return obj.to_dict()
         else:
             # Upstream MongoEngine
-            doc_data = dict(obj._data)
-        if None in doc_data:
-            del doc_data[None]
-        return doc_data
+            return dict(obj._data)
 
 
 class MongoReference(Field):

--- a/cleancat/mongo.py
+++ b/cleancat/mongo.py
@@ -8,7 +8,7 @@ from mongoengine import ValidationError as MongoValidationError
 
 from .base import (
     Embedded, EmbeddedReference, Field, ReferenceNotFoundError,
-    ValidationError, basestring
+    ValidationError, str_type
 )
 
 
@@ -68,7 +68,7 @@ class MongoReference(Field):
     Example document: ReferenceField(Doc)
     """
 
-    base_type = basestring
+    base_type = str_type
 
     def __init__(self, document_class=None, **kwargs):
         self.document_class = document_class

--- a/cleancat/mongo.py
+++ b/cleancat/mongo.py
@@ -79,7 +79,7 @@ class MongoReference(Field):
         try:
             return self.document_class.objects.get(pk=value)
         except self.document_class.DoesNotExist:
-            raise ReferenceNotFoundError
+            raise ValidationError('Object does not exist.')
 
     def serialize(self, value):
         if value:

--- a/cleancat/mongo.py
+++ b/cleancat/mongo.py
@@ -7,7 +7,8 @@ them via `from cleancat.mongo import ...`.
 from mongoengine import ValidationError as MongoValidationError
 
 from .base import (
-    Embedded, EmbeddedReference, Field, ValidationError, basestring
+    Embedded, EmbeddedReference, Field, ReferenceNotFoundError,
+    ValidationError, basestring
 )
 
 
@@ -44,7 +45,7 @@ class MongoEmbeddedReference(EmbeddedReference):
         try:
             return doc_cls.objects.get(pk=pk)
         except doc_cls.DoesNotExist:
-            raise ValidationError('Object does not exist.')
+            raise ReferenceNotFoundError
         except MongoValidationError as e:
             raise ValidationError(str(e))
 
@@ -78,7 +79,7 @@ class MongoReference(Field):
         try:
             return self.document_class.objects.get(pk=value)
         except self.document_class.DoesNotExist:
-            raise ValidationError('Object does not exist.')
+            raise ReferenceNotFoundError
 
     def serialize(self, value):
         if value:

--- a/cleancat/sqla.py
+++ b/cleancat/sqla.py
@@ -1,0 +1,40 @@
+"""
+This module contains CleanCat fields specific to SQLAlchemy. SQLA is not
+a required dependency, hence to use these fields, you'll have to import
+them via `from cleancat.sqla import ...`.
+"""
+
+from sqlalchemy import inspect
+
+from .base import EmbeddedReference, ValidationError
+
+
+def object_as_dict(obj):
+    """Turn an SQLAlchemy model into a dict of field names and values.
+
+    Based on https://stackoverflow.com/a/37350445/1579058
+    """
+    return {c.key: getattr(obj, c.key)
+            for c in inspect(obj).mapper.column_attrs}
+
+
+class SQLAEmbeddedReference(EmbeddedReference):
+    """
+    Represents an embedded reference where the object class is an SQLAlchemy
+    model.
+
+    Examples of passed data and how it's handled:
+    {'id': 'existing_id', 'foo': 'bar'} -> updates an existing model
+    {'id': 'non-existing_id', 'foo': 'bar'} -> fails bcos the ID is not valid
+    {'foo': 'bar'} -> creates a new model instance
+    """
+
+    def fetch_existing(self, pk):
+        model_cls = self.object_class
+        model = model_cls.query.get(pk)
+        if not model:
+            raise ValidationError('Object does not exist.')
+        return model
+
+    def get_orig_data_from_existing(self, obj):
+        return object_as_dict(obj)

--- a/cleancat/sqla.py
+++ b/cleancat/sqla.py
@@ -6,7 +6,7 @@ them via `from cleancat.sqla import ...`.
 
 from sqlalchemy import inspect
 
-from .base import EmbeddedReference, ValidationError
+from .base import EmbeddedReference, ReferenceNotFoundError
 
 
 def object_as_dict(obj):
@@ -33,7 +33,7 @@ class SQLAEmbeddedReference(EmbeddedReference):
         model_cls = self.object_class
         model = model_cls.query.get(pk)
         if not model:
-            raise ValidationError('Object does not exist.')
+            raise ReferenceNotFoundError
         return model
 
     def get_orig_data_from_existing(self, obj):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 flake8
+mongoengine
 python-dateutil
+pytest
 pytz
+sqlalchemy

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,10 @@
+[aliases]
+test=pytest
+
+[tool:pytest]
+python_files=tests/*.py
+testpaths=tests
+
 [flake8]
 ignore=E501
 exclude=venv,.tox,.eggs,build

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@ from setuptools import setup
 
 install_requirements = [
     'python-dateutil',
-    'pytz'
+    'pytz',
+    'six'
 ]
 test_requirements = install_requirements + [
     'pytest',

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,14 @@
 from setuptools import setup
 
-test_requirements = [
-    'nose',
+install_requirements = [
+    'python-dateutil',
+    'pytz'
+]
+test_requirements = install_requirements + [
+    'pytest',
     'coverage',
+    'mongoengine',
+    'sqlalchemy'
 ]
 
 setup(
@@ -19,12 +25,11 @@ setup(
     packages=[
         'cleancat',
     ],
-    test_suite='nose.collector',
     zip_safe=False,
     platforms='any',
-    install_requires=[
-        'python-dateutil',
-    ],
+    install_requires=install_requirements,
+    setup_requires=['pytest-runner'],
+    test_suite='tests',
     tests_require=test_requirements,
     extras_require={'test': test_requirements},
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from setuptools import setup
 install_requirements = [
     'python-dateutil',
     'pytz',
-    'six'
 ]
 test_requirements = install_requirements + [
     'pytest',

--- a/tests/sqla.py
+++ b/tests/sqla.py
@@ -2,8 +2,10 @@ import unittest
 
 import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import scoped_session, sessionmaker
 
-from cleancat.sqla import object_as_dict
+from cleancat import Integer, Schema, String, ValidationError
+from cleancat.sqla import SQLAEmbeddedReference, object_as_dict
 
 
 class ObjectAsDictTestCase(unittest.TestCase):
@@ -23,6 +25,91 @@ class ObjectAsDictTestCase(unittest.TestCase):
             'age': 30,
             'name': 'Steve'
         }
+
+
+class SQLAEmbeddedReferenceTestCase(unittest.TestCase):
+
+    def setUp(self):
+        super(SQLAEmbeddedReferenceTestCase, self).setUp()
+
+        Base = declarative_base()
+
+        class Person(Base):
+            __tablename__ = 'cleancattest'
+            id = sa.Column(sa.Integer, primary_key=True)
+            name = sa.Column(sa.String)
+            age = sa.Column(sa.Integer)
+
+        self.Person = Person
+
+        engine = sa.create_engine('sqlite:///:memory:')
+        Base.metadata.create_all(engine)
+        self.session = scoped_session(sessionmaker(bind=engine))
+        self.Person.query = self.session.query_property()
+
+    def test_create(self):
+        class PersonSchema(Schema):
+            name = String()
+            age = Integer()
+
+        class BookSchema(Schema):
+            author = SQLAEmbeddedReference(self.Person, PersonSchema)
+
+        schema = BookSchema({
+            'author': {
+                'name': 'New Author',
+                'age': 30
+            }
+        })
+        data = schema.full_clean()
+        author = data['author']
+        assert isinstance(author, self.Person)
+        assert not author.id
+        assert author.name == 'New Author'
+        assert author.age == 30
+
+    def test_update(self):
+        class PersonSchema(Schema):
+            name = String()
+            age = Integer()
+
+        class BookSchema(Schema):
+            author = SQLAEmbeddedReference(self.Person, PersonSchema)
+
+        steve = self.Person(name='Steve', age=30)
+        self.session.add(steve)
+        self.session.commit()
+
+        schema = BookSchema({
+            'author': {
+                'id': str(steve.id),
+                'name': 'Updated',
+                'age': 50
+            }
+        })
+        data = schema.full_clean()
+        author = data['author']
+        assert isinstance(author, self.Person)
+        assert author.id == steve.id
+        assert author.name == 'Updated'
+        assert author.age == 50
+
+    def test_update_missing(self):
+        class PersonSchema(Schema):
+            name = String()
+            age = Integer()
+
+        class BookSchema(Schema):
+            author = SQLAEmbeddedReference(self.Person, PersonSchema)
+
+        schema = BookSchema({
+            'author': {
+                'id': 123456789,
+                'name': 'Arbitrary Non-existent ID'
+            }
+        })
+        self.assertRaises(ValidationError, schema.full_clean)
+        assert schema.field_errors == {'author': 'Object does not exist.'}
 
 
 if __name__ == '__main__':

--- a/tests/sqla.py
+++ b/tests/sqla.py
@@ -1,0 +1,29 @@
+import unittest
+
+import sqlalchemy as sa
+from sqlalchemy.ext.declarative import declarative_base
+
+from cleancat.sqla import object_as_dict
+
+
+class ObjectAsDictTestCase(unittest.TestCase):
+
+    def test_object_as_dict(self):
+        Base = declarative_base()
+
+        class Person(Base):
+            __tablename__ = 'cleancattest'
+            id = sa.Column(sa.Integer, primary_key=True)
+            name = sa.Column(sa.String)
+            age = sa.Column(sa.Integer)
+
+        steve = Person(name='Steve', age=30)
+        assert object_as_dict(steve) == {
+            'id': None,
+            'age': 30,
+            'name': 'Steve'
+        }
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR abstracts away common logic of an embedded reference, makes `MongoEmbeddedReference` inherit from it, and adds an `SQLAEmbeddedReference`.

TODOs:
- [x] Add some tests for the `SQLAEmbeddedReference`
- [x] Run *all* the tests on our CI, not just `tests/__init__.py`.
