### PR TITLE
Fix serializing None values

### DIFF
--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -315,8 +315,10 @@ class List(Field):
         return data
 
     def serialize(self, value):
-        if value is not None:
-            return [self.field_instance.serialize(item) for item in value]
+        # Serialize all falsy values as an empty list.
+        if not value:
+            value = []
+        return [self.field_instance.serialize(item) for item in value]
 
 
 class Dict(Field):
@@ -324,6 +326,10 @@ class Dict(Field):
 
     def has_value(self, value):
         return bool(value)
+
+    def serialize(self, value):
+        # Serialize all falsy values as an empty dict.
+        return value or {}
 
 
 class Embedded(Dict):

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -317,7 +317,7 @@ class List(Field):
     def serialize(self, value):
         # Serialize all falsy values as an empty list.
         if not value:
-            value = []
+            return []
         return [self.field_instance.serialize(item) for item in value]
 
 

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -664,8 +664,8 @@ class Schema(object):
         data = {}
         for field_name, field in self.fields.items():
             value = self.data[field_name]
-            if value is not None:
-                data[field_name] = field.serialize(value)
-            else:
+            if value is None:
                 data[field_name] = None
+            else:
+                data[field_name] = field.serialize(value)
         return data

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -663,5 +663,9 @@ class Schema(object):
     def serialize(self):
         data = {}
         for field_name, field in self.fields.items():
-            data[field_name] = field.serialize(self.data[field_name])
+            value = self.data[field_name]
+            if value is not None:
+                data[field_name] = field.serialize(value)
+            else:
+                data[field_name] = None
         return data

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -376,7 +376,7 @@ class EmbeddedReference(Dict):
         self.object_class = object_class
         self.schema_class = schema_class
         self.pk_field = pk_field
-        super(EmbeddedReference, self).__init__(schema_class, **kwargs)
+        super(EmbeddedReference, self).__init__(**kwargs)
 
     def clean(self, value):
         # Clean the dict first.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,8 +5,9 @@ import sys
 import unittest
 
 from cleancat import (
-    Bool, Choices, DateTime, Email, Embedded, Enum, Integer, List, Regex,
-    RelaxedURL, Schema, SortedSet, String, TrimmedString, URL, ValidationError
+    Bool, Choices, DateTime, Dict, Email, Embedded, Enum, Integer, List,
+    Regex, RelaxedURL, Schema, SortedSet, String, TrimmedString, URL,
+    ValidationError
 )
 from cleancat.utils import ValidationTestCase
 
@@ -601,6 +602,42 @@ class SerializationTestCase(unittest.TestCase):
             'embedded': {'date_time': '2000-01-01T00:00:00'},
         })
 
+    def test_serialization_optional_fields(self):
+        class EmbeddedSchema(Schema):
+            date_time = DateTime()
+
+        class TestSchema(Schema):
+            name = String(required=True)
+            string = String(required=False)
+            boolean = Bool(required=False)
+            date_time = DateTime(required=False)
+            integer = Integer(required=False)
+            lst = List(DateTime(), required=False)
+            embedded = Embedded(EmbeddedSchema, required=False)
+            dictionary = Dict(required=False)
+
+        schema = TestSchema(data={
+            'name': 'One Required Field',
+            'string': None,
+            'boolean': None,
+            'date_time': None,
+            'integer': None,
+            'lst': None,
+            'embedded': None,
+            'dictionary': None,
+        })
+        serialized = schema.serialize()
+        self.assertEqual(serialized, {
+            'name': 'One Required Field',
+            'string': None,
+            'boolean': None,
+            'date_time': None,
+            'integer': None,
+            'lst': None,
+            'embedded': None,
+            'dictionary': None,
+        })
+
     @unittest.skipIf(sys.version_info < (3, 4), 'enum unavailable')
     def test_serialization_enum(self):
         import enum
@@ -611,16 +648,19 @@ class SerializationTestCase(unittest.TestCase):
 
         class TestSchema(Schema):
             enum = Enum(MyChoices)
+            optional_enum = Enum(MyChoices)
             lst = List(Enum(MyChoices))
 
         schema = TestSchema(data={
             'enum': MyChoices.A,
+            'optional_enum': None,
             'lst': [MyChoices.A, MyChoices.B],
         })
 
         serialized = schema.serialize()
         self.assertEqual(serialized, {
             'enum': 'a',
+            'optional_enum': None,
             'lst': ['a', 'b'],
         })
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -609,33 +609,39 @@ class SerializationTestCase(unittest.TestCase):
         class TestSchema(Schema):
             name = String(required=True)
             string = String(required=False)
+            choice = Choices(['a', 'b'], required=False)
             boolean = Bool(required=False)
             date_time = DateTime(required=False)
             integer = Integer(required=False)
-            lst = List(DateTime(), required=False)
             embedded = Embedded(EmbeddedSchema, required=False)
+            lst = List(DateTime(), required=False)
+            sorted_set = SortedSet(String(), required=False)
             dictionary = Dict(required=False)
 
         schema = TestSchema(data={
             'name': 'One Required Field',
             'string': None,
+            'choice': None,
             'boolean': None,
             'date_time': None,
             'integer': None,
-            'lst': None,
             'embedded': None,
+            'lst': None,
+            'sorted_set': None,
             'dictionary': None,
         })
         serialized = schema.serialize()
         self.assertEqual(serialized, {
             'name': 'One Required Field',
             'string': None,
+            'choice': None,
             'boolean': None,
             'date_time': None,
             'integer': None,
-            'lst': None,
             'embedded': None,
-            'dictionary': None,
+            'lst': [],
+            'sorted_set': [],
+            'dictionary': {},
         })
 
     @unittest.skipIf(sys.version_info < (3, 4), 'enum unavailable')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -648,7 +648,7 @@ class SerializationTestCase(unittest.TestCase):
 
         class TestSchema(Schema):
             enum = Enum(MyChoices)
-            optional_enum = Enum(MyChoices)
+            optional_enum = Enum(MyChoices, required=False)
             lst = List(Enum(MyChoices))
 
         schema = TestSchema(data={

--- a/tests/mongo.py
+++ b/tests/mongo.py
@@ -43,6 +43,21 @@ class MongoReferenceTestCase(MongoValidationTestCase):
             {'field-errors': ['author_id']}
         )
 
+    def test_optional(self):
+        class BookSchema(Schema):
+            title = String()
+            author_id = MongoReference(self.Person, required=False)
+
+        schema = BookSchema({
+            'title': 'Book without an author',
+            'author_id': None
+        })
+        data = schema.full_clean()
+        assert data == {
+            'title': 'Book without an author',
+            'author_id': None
+        }
+
 
 class MongoEmbeddedReferenceTestCase(MongoValidationTestCase):
 
@@ -100,6 +115,25 @@ class MongoEmbeddedReferenceTestCase(MongoValidationTestCase):
         })
         self.assertRaises(ValidationError, schema.full_clean)
         assert schema.field_errors == {'author': 'Object does not exist.'}
+
+    def test_optional(self):
+        class PersonSchema(Schema):
+            name = String()
+
+        class BookSchema(Schema):
+            title = String()
+            author = MongoEmbeddedReference(self.Person, PersonSchema,
+                                            required=False)
+
+        schema = BookSchema({
+            'title': 'Book without an author',
+            'author': None
+        })
+        data = schema.full_clean()
+        assert data == {
+            'title': 'Book without an author',
+            'author': None
+        }
 
 
 if __name__ == '__main__':

--- a/tests/mongo.py
+++ b/tests/mongo.py
@@ -1,5 +1,6 @@
 import unittest
 
+import pytest
 from bson import ObjectId
 from mongoengine import Document, StringField, connect
 
@@ -113,7 +114,7 @@ class MongoEmbeddedReferenceTestCase(MongoValidationTestCase):
                 'name': 'Arbitrary Non-existent Object ID'
             }
         })
-        self.assertRaises(ValidationError, schema.full_clean)
+        pytest.raises(ValidationError, schema.full_clean)
         assert schema.field_errors == {'author': 'Object does not exist.'}
 
     def test_optional(self):

--- a/tests/sqla.py
+++ b/tests/sqla.py
@@ -111,6 +111,25 @@ class SQLAEmbeddedReferenceTestCase(unittest.TestCase):
         self.assertRaises(ValidationError, schema.full_clean)
         assert schema.field_errors == {'author': 'Object does not exist.'}
 
+    def test_optional(self):
+        class PersonSchema(Schema):
+            name = String()
+
+        class BookSchema(Schema):
+            title = String()
+            author = SQLAEmbeddedReference(self.Person, PersonSchema,
+                                           required=False)
+
+        schema = BookSchema({
+            'title': 'Book without an author',
+            'author': None
+        })
+        data = schema.full_clean()
+        assert data == {
+            'title': 'Book without an author',
+            'author': None
+        }
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/sqla.py
+++ b/tests/sqla.py
@@ -1,5 +1,6 @@
 import unittest
 
+import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
@@ -8,23 +9,21 @@ from cleancat import Integer, Schema, String, ValidationError
 from cleancat.sqla import SQLAEmbeddedReference, object_as_dict
 
 
-class ObjectAsDictTestCase(unittest.TestCase):
+def test_object_as_dict():
+    Base = declarative_base()
 
-    def test_object_as_dict(self):
-        Base = declarative_base()
+    class Person(Base):
+        __tablename__ = 'cleancattest'
+        id = sa.Column(sa.Integer, primary_key=True)
+        name = sa.Column(sa.String)
+        age = sa.Column(sa.Integer)
 
-        class Person(Base):
-            __tablename__ = 'cleancattest'
-            id = sa.Column(sa.Integer, primary_key=True)
-            name = sa.Column(sa.String)
-            age = sa.Column(sa.Integer)
-
-        steve = Person(name='Steve', age=30)
-        assert object_as_dict(steve) == {
-            'id': None,
-            'age': 30,
-            'name': 'Steve'
-        }
+    steve = Person(name='Steve', age=30)
+    assert object_as_dict(steve) == {
+        'id': None,
+        'age': 30,
+        'name': 'Steve'
+    }
 
 
 class SQLAEmbeddedReferenceTestCase(unittest.TestCase):
@@ -108,7 +107,7 @@ class SQLAEmbeddedReferenceTestCase(unittest.TestCase):
                 'name': 'Arbitrary Non-existent ID'
             }
         })
-        self.assertRaises(ValidationError, schema.full_clean)
+        pytest.raises(ValidationError, schema.full_clean)
         assert schema.field_errors == {'author': 'Object does not exist.'}
 
     def test_optional(self):


### PR DESCRIPTION
Before this PR, serializing an object could fail even if its data was clean. For example, if you had an optional `DateTime` field and tried to serialize `{'dt_field_name': None}`, you'd get `AttributeError: 'NoneType' object has no attribute 'isoformat'`. That's because the overridden `DateTime.serialize` method expects a valid `datetime.datetime` value: https://github.com/closeio/cleancat/blob/48b99263e89e7909d305e8d861e6098fdba6476d/cleancat/base.py#L177-L178


All the other overridden `serialize` methods (e.g. `List.serialize`, `Enum.serialize`, etc.) follow the same pattern. I figured this is an issue we can tackle generically and *never* call `field.serialize(None)`.

An alternative would be to fix the overridden methods by prefixing them all with `if value is None: return`, but I think that would lead to a lot of copy-pasting as we create/override more `serialize` methods in the future.