### PR TITLE
Allow to narrow down choices in an Enum field

### DIFF
--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -500,12 +500,15 @@ class Enum(Choices):
         * an enum.Enum class (in which case all of its values will become
           valid choices),
         * a list containing a subset of the enum's choices (e.g.
-          `[SomeEnumCls.OptionA, SomeEnumCls.OptionB]`).
+          `[SomeEnumCls.OptionA, SomeEnumCls.OptionB]`). You should provide
+          more than one choice in this list and *all* of the choices should
+          belong to the same enum class.
         """
         is_cls = inspect.isclass(choices)
         if is_cls:
             self.enum_cls = choices
         else:
+            assert choices, 'You need to provide at least one enum choice.'
             self.enum_cls = choices[0].__class__
         return super(Enum, self).__init__(choices, **kwargs)
 

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -1,4 +1,5 @@
 import datetime
+import inspect
 import re
 import sys
 
@@ -492,11 +493,20 @@ class Enum(Choices):
     """
     Like Choices, but expects a Python 3 Enum.
     """
-    def __init__(self, enum_cls, choices=None, **kwargs):
-        self.enum_cls = enum_cls
-        if not choices:
-            # Enums are iterable, so we can safely specify choices like that.
-            choices = enum_cls
+    def __init__(self, choices, **kwargs):
+        """Initialize the Enum field.
+
+        The `choices` param can be either:
+        * an enum.Enum class (in which case all of its values will become
+          valid choices),
+        * a list containing a subset of the enum's choices (e.g.
+          `[SomeEnumCls.OptionA, SomeEnumCls.OptionB]`).
+        """
+        is_cls = inspect.isclass(choices)
+        if is_cls:
+            self.enum_cls = choices
+        else:
+            self.enum_cls = choices[0].__class__
         return super(Enum, self).__init__(choices, **kwargs)
 
     def get_choices(self):

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -582,8 +582,8 @@ class Enum(Choices):
         * an enum.Enum class (in which case all of its values will become
           valid choices),
         * a list containing a subset of the enum's choices (e.g.
-          `[SomeEnumCls.OptionA, SomeEnumCls.OptionB]`). You should provide
-          more than one choice in this list and *all* of the choices should
+          `[SomeEnumCls.OptionA, SomeEnumCls.OptionB]`). You must provide
+          more than one choice in this list and *all* of the choices must
           belong to the same enum class.
         """
         is_cls = inspect.isclass(choices)

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -456,7 +456,8 @@ class Choices(Field):
     """
     A field that accepts the given choices.
     """
-    def __init__(self, choices, case_insensitive=False, error_invalid_choice=None, **kwargs):
+    def __init__(self, choices, case_insensitive=False,
+                 error_invalid_choice=None, **kwargs):
         super(Choices, self).__init__(**kwargs)
         self.choices = choices
         self.case_insensitive = case_insensitive
@@ -491,12 +492,19 @@ class Enum(Choices):
     """
     Like Choices, but expects a Python 3 Enum.
     """
+    def __init__(self, enum_cls, choices=None, **kwargs):
+        self.enum_cls = enum_cls
+        if not choices:
+            # Enums are iterable, so we can safely specify choices like that.
+            choices = enum_cls
+        return super(Enum, self).__init__(choices, **kwargs)
+
     def get_choices(self):
         return [choice.value for choice in self.choices]
 
     def clean(self, value):
         value = super(Enum, self).clean(value)
-        return self.choices(value)
+        return self.enum_cls(value)
 
     def serialize(self, choice):
         if choice is not None:

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ install_requirements = [
 test_requirements = install_requirements + [
     'pytest',
     'coverage',
+    'enum34',
     'mongoengine',
     'sqlalchemy'
 ]

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import sys
 from setuptools import setup
 
 install_requirements = [
@@ -7,10 +8,12 @@ install_requirements = [
 test_requirements = install_requirements + [
     'pytest',
     'coverage',
-    'enum34',
     'mongoengine',
     'sqlalchemy'
 ]
+
+if sys.version_info[:2] < (3, 4):
+    test_requirements += ['enum34']
 
 setup(
     name='cleancat',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -338,7 +338,7 @@ class FieldTestCase(ValidationTestCase):
             C = 'c'
 
         class ChoiceSchema(Schema):
-            choice = Enum(MyChoices, choices=[MyChoices.A, MyChoices.B])
+            choice = Enum([MyChoices.A, MyChoices.B])
 
         self.assertValid(ChoiceSchema({'choice': 'a'}), {'choice': MyChoices.A})
         self.assertValid(ChoiceSchema({'choice': 'b'}), {'choice': MyChoices.B})

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import datetime
+import enum
 import re
-import sys
 import unittest
 
 import pytest
@@ -319,16 +319,26 @@ class FieldTestCase(ValidationTestCase):
         self.assertInvalid(CaseInsensitiveChoiceSchema({'choice': 'world '}), {'field-errors': ['choice']})
         self.assertInvalid(CaseInsensitiveChoiceSchema({'choice': 'invalid'}), {'field-errors': ['choice']})
 
-    @unittest.skipIf(sys.version_info < (3, 4), 'enum unavailable')
     def test_enum(self):
-        import enum
-
         class MyChoices(enum.Enum):
             A = 'a'
             B = 'b'
 
         class ChoiceSchema(Schema):
             choice = Enum(MyChoices)
+
+        self.assertValid(ChoiceSchema({'choice': 'a'}), {'choice': MyChoices.A})
+        self.assertValid(ChoiceSchema({'choice': 'b'}), {'choice': MyChoices.B})
+        self.assertInvalid(ChoiceSchema({'choice': 'c'}), {'field-errors': ['choice']})
+
+    def test_enum_with_choices(self):
+        class MyChoices(enum.Enum):
+            A = 'a'
+            B = 'b'
+            C = 'c'
+
+        class ChoiceSchema(Schema):
+            choice = Enum(MyChoices, choices=[MyChoices.A, MyChoices.B])
 
         self.assertValid(ChoiceSchema({'choice': 'a'}), {'choice': MyChoices.A})
         self.assertValid(ChoiceSchema({'choice': 'b'}), {'choice': MyChoices.B})
@@ -644,10 +654,7 @@ class SerializationTestCase(unittest.TestCase):
             'dictionary': {},
         }
 
-    @unittest.skipIf(sys.version_info < (3, 4), 'enum unavailable')
     def test_serialization_enum(self):
-        import enum
-
         class MyChoices(enum.Enum):
             A = 'a'
             B = 'b'


### PR DESCRIPTION
This PR:
* Allows you to only consider a subset of a specific enum's options valid.
* Installs `enum34` in tests so that we can test the `Enum` field in Python v2.
* Is backward-compatible, unless someone initialized `Enum()` using positional arguments (highly unlikely).