### PR TITLE
Fix raw field name serialization

### DIFF
--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -679,6 +679,7 @@ class Schema(object):
     def serialize(self):
         data = {}
         for field_name, field in self.fields.items():
+            raw_field_name = field.raw_field_name or field_name
             value = self.data[field_name]
-            data[field_name] = field.serialize(value)
+            data[raw_field_name] = field.serialize(value)
         return data

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -671,5 +671,19 @@ class SerializationTestCase(unittest.TestCase):
         }
 
 
+def test_raw_field_name():
+    class TestSchema(Schema):
+        value = String(raw_field_name='value_id')
+
+    schema = TestSchema(raw_data={'value_id': 'val_xyz'})
+
+    schema.full_clean()
+    assert schema.data == {'value': 'val_xyz'}
+
+    serialized = schema.serialize()
+    assert serialized == {'value_id': 'val_xyz'}
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -684,6 +684,5 @@ def test_raw_field_name():
     assert serialized == {'value_id': 'val_xyz'}
 
 
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The field name coming in (i.e. during the "clean" phase) should be the same as the field name going out (during serialization).