### PR TITLE
Stop using hasattr

### DIFF
--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -687,11 +687,20 @@ class Schema(object):
         """
         data = {}
         for field_name in cls.get_fields():
-            if getattr(obj, field_name, None):
+            try:
                 value = getattr(obj, field_name)
-                if callable(value):
-                    value = value()
-                data[field_name] = value
+            except AttributeError:
+                # If the field doesn't exist on the object, fail gracefully
+                # and don't include the field in the data dict at all. Fail
+                # loudly if the field exists but produces a different error
+                # (edge case: accessing an *existing* field could technically
+                # produce an unrelated AttributeError).
+                continue
+
+            if callable(value):
+                value = value()
+            data[field_name] = value
+
         return data
 
     def __init__(self, raw_data=None, data=None):

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -687,7 +687,7 @@ class Schema(object):
         """
         data = {}
         for field_name in cls.get_fields():
-            if hasattr(obj, field_name):
+            if getattr(obj, field_name, None):
                 value = getattr(obj, field_name)
                 if callable(value):
                     value = value()

--- a/cleancat/mongo.py
+++ b/cleancat/mongo.py
@@ -51,7 +51,7 @@ class MongoEmbeddedReference(EmbeddedReference):
 
     def get_orig_data_from_existing(self, obj):
         # Get a dict of existing document's field names and values.
-        if hasattr(obj, 'to_dict'):
+        if getattr(obj, 'to_dict', None):
             # MongoMallard
             return obj.to_dict()
         else:


### PR DESCRIPTION
`hasattr`'s usage is discouraged because it swallows exceptions, some of which should've bubbled to the surface.