### PR TITLE
Speed up the Regex field

### DIFF
--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -160,7 +160,9 @@ class Regex(String):
             self.regex_message = regex_message
 
     def get_regex(self):
-        return re.compile(self.regex, self.regex_flags)
+        if not getattr(self, '_compiled_regex', None):
+            self._compiled_regex = re.compile(self.regex, self.regex_flags)
+        return self._compiled_regex
 
     def clean(self, value):
         value = super(Regex, self).clean(value)

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 test=pytest
 
 [flake8]
-ignore=E501
+ignore=E501,W504
 exclude=venv,.tox,.eggs,build


### PR DESCRIPTION
This PR speeds up the `Regex` field (and all fields based on it, i.e. `DateTime`, `Email`, `URL`, and `RelaxedURL`) by caching the compiled regular expression the first time `Regex.clean(...)` is called.

It's worth noting that Python already implements its own caching of regex patterns. [Docs for `re.compile`](https://docs.python.org/3/library/re.html#re.compile) say:

> **Note:** The compiled versions of the most recent patterns passed to `re.compile()` and the module-level matching functions are cached, so programs that use only a few regular expressions at a time needn’t worry about compiling regular expressions. 

That said, on my MBP I still see a consistent difference in performance when running the following code on `master` vs on this branch:
```py
from cleancat import Email
field = Email()
%timeit field.clean('stefan@close.io')
```

`master` runs at ~4us per loop vs this branch spends ~3.4us per loop, meaning we get a ~15% boost. Given how simple this optimization is and how often we validate data, I think it's worth it.