### PR TITLE
Compatibility code for external error message in APIs

### DIFF
--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -5,8 +5,8 @@ import sys
 from uuid import UUID as PythonUUID
 
 import pytz
+import six
 from dateutil import parser
-
 
 if sys.version_info[0] == 3:
     str_type = str
@@ -122,7 +122,15 @@ class String(Field):
             raise ValidationError(err_msg)
 
     def clean(self, value):
-        value = super(String, self).clean(value)
+        try:
+            value = super(String, self).clean(value)
+        except ValidationError as exc:
+            # This is a layer to keep the external API unchanged once we
+            # migrate to Python 3.
+            if six.PY3 and str(exc) == 'Value must be of str type.':
+                raise ValidationError('Value must be of basestring type.')
+            raise
+
         self._check_length(value)
         return value
 
@@ -137,7 +145,15 @@ class TrimmedString(String):
     def clean(self, value):
         # XXX we skip a level of inheritance so that we can perform length
         # checks *after* trimming.
-        value = super(String, self).clean(value)
+        try:
+            value = super(String, self).clean(value)
+        except ValidationError as exc:
+            # This is a layer to keep the external API unchanged once we
+            # migrate to Python 3.
+            if six.PY3 and str(exc) == 'Value must be of str type.':
+                raise ValidationError('Value must be of basestring type.')
+            raise
+
         if value:
             value = value.strip()
         self._check_length(value)
@@ -203,7 +219,12 @@ class DateTime(Regex):
         try:
             dt = parser.parse(value)
         except Exception as e:
-            raise ValidationError('Could not parse date: %s' % str(e))
+            # This is a layer to keep the external API unchanged once we
+            # migrate to Python 3.
+            error_message = str(e)
+            if six.PY3 and error_message.startswith('year 0 is out of range'):
+                error_message = 'year is out of range'
+            raise ValidationError('Could not parse date: %s' % error_message)
         if self.min_date:
             if dt.tzinfo is not None and self.min_date.tzinfo is None:
                 min_date = self.min_date.replace(tzinfo=pytz.utc)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -78,7 +78,7 @@ class TestStringField:
         assert e.value.args[0] == 'default'
 
     def test_it_enforces_valid_data_type(self):
-        expected_err_msg = 'Value must be of basestring type.'
+        expected_err_msg = 'Value must be of str type.'
         with pytest.raises(ValidationError, match=expected_err_msg):
             String().clean(True)
 
@@ -157,7 +157,7 @@ class TestTrimmedStringField:
         assert e.value.args[0] == ''
 
     def test_it_enforces_valid_data_type(self):
-        expected_err_msg = 'Value must be of basestring type.'
+        expected_err_msg = 'Value must be of str type.'
         with pytest.raises(ValidationError, match=expected_err_msg):
             TrimmedString().clean(True)
 
@@ -254,7 +254,7 @@ class TestRegexField:
         assert e.value.args[0] == ''
 
     def test_it_enforces_valid_data_type(self):
-        expected_err_msg = 'Value must be of basestring type.'
+        expected_err_msg = 'Value must be of str type.'
         with pytest.raises(ValidationError, match=expected_err_msg):
             Regex('^[a-z]$').clean(True)
 
@@ -273,11 +273,8 @@ class TestDateTimeField:
         assert DateTime().clean(raw) == expected
 
     def test_it_rejects_invalid_year_range(self):
-        with pytest.raises(ValidationError) as e:
+        with pytest.raises(ValidationError, match='Could not parse datetime'):
             DateTime().clean('0000-01-01T00:00:00-08:00')
-        assert e.value.args[0].startswith(
-            'Could not parse date: year is out of range'
-        )
 
     @pytest.mark.parametrize('value', ['2012a', 'alksdjf', '111111111'])
     def test_it_rejects_invalid_dates(self, value):
@@ -298,7 +295,7 @@ class TestDateTimeField:
         assert e.value.args[0] is None
 
     def test_it_enforces_valid_data_type(self):
-        expected_err_msg = 'Value must be of basestring type.'
+        expected_err_msg = 'Value must be of str type.'
         with pytest.raises(ValidationError, match=expected_err_msg):
             DateTime().clean(True)
 
@@ -363,7 +360,7 @@ class TestEmailField:
         assert e.value.args[0] == ''
 
     def test_it_enforces_valid_data_type(self):
-        expected_err_msg = 'Value must be of basestring type.'
+        expected_err_msg = 'Value must be of str type.'
         with pytest.raises(ValidationError, match=expected_err_msg):
             Email().clean(True)
 
@@ -655,7 +652,7 @@ class TestURLField:
 
     @pytest.mark.parametrize('value', [23.0, True])
     def test_it_enforces_valid_data_type(self, value):
-        expected_err_msg = 'Value must be of basestring type.'
+        expected_err_msg = 'Value must be of str type.'
         with pytest.raises(ValidationError, match=expected_err_msg):
             URL().clean(value)
 
@@ -696,7 +693,7 @@ class TestRelaxedURLField:
 
     @pytest.mark.parametrize('value', [23.0, True])
     def test_it_enforces_valid_data_type(self, value):
-        expected_err_msg = 'Value must be of basestring type.'
+        expected_err_msg = 'Value must be of str type.'
         with pytest.raises(ValidationError, match=expected_err_msg):
             RelaxedURL().clean(value)
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -8,6 +8,7 @@ import pytest
 from pytz import utc
 
 from cleancat import (
+    URL,
     Bool,
     Choices,
     DateTime,
@@ -25,15 +26,14 @@ from cleancat import (
     StopValidation,
     String,
     TrimmedString,
-    URL,
     ValidationError,
 )
 from cleancat.base import (
-    PolymorphicField,
-    EmbeddedFactory,
-    LazyField,
     UUID,
     CleanDict,
+    EmbeddedFactory,
+    LazyField,
+    PolymorphicField,
 )
 
 
@@ -78,8 +78,7 @@ class TestStringField:
         assert e.value.args[0] == 'default'
 
     def test_it_enforces_valid_data_type(self):
-        # TODO make this consistent between Py2 & Py3
-        expected_err_msg = 'Value must be of (str|basestring) type.'
+        expected_err_msg = 'Value must be of basestring type.'
         with pytest.raises(ValidationError, match=expected_err_msg):
             String().clean(True)
 
@@ -158,8 +157,7 @@ class TestTrimmedStringField:
         assert e.value.args[0] == ''
 
     def test_it_enforces_valid_data_type(self):
-        # TODO make this consistent between Py2 & Py3
-        expected_err_msg = 'Value must be of (str|basestring) type.'
+        expected_err_msg = 'Value must be of basestring type.'
         with pytest.raises(ValidationError, match=expected_err_msg):
             TrimmedString().clean(True)
 
@@ -256,8 +254,7 @@ class TestRegexField:
         assert e.value.args[0] == ''
 
     def test_it_enforces_valid_data_type(self):
-        # TODO make this consistent between Py2 & Py3
-        expected_err_msg = 'Value must be of (str|basestring) type.'
+        expected_err_msg = 'Value must be of basestring type.'
         with pytest.raises(ValidationError, match=expected_err_msg):
             Regex('^[a-z]$').clean(True)
 
@@ -278,10 +275,8 @@ class TestDateTimeField:
     def test_it_rejects_invalid_year_range(self):
         with pytest.raises(ValidationError) as e:
             DateTime().clean('0000-01-01T00:00:00-08:00')
-        assert e.value.args[0] in (
-            # TODO make this consistent between Py2 & Py3
-            'Could not parse date: year is out of range',  # Py2
-            'Could not parse date: year 0 is out of range',  # Py3
+        assert e.value.args[0].startswith(
+            'Could not parse date: year is out of range'
         )
 
     @pytest.mark.parametrize('value', ['2012a', 'alksdjf', '111111111'])
@@ -303,8 +298,7 @@ class TestDateTimeField:
         assert e.value.args[0] is None
 
     def test_it_enforces_valid_data_type(self):
-        # TODO make this consistent between Py2 & Py3
-        expected_err_msg = 'Value must be of (str|basestring) type.'
+        expected_err_msg = 'Value must be of basestring type.'
         with pytest.raises(ValidationError, match=expected_err_msg):
             DateTime().clean(True)
 
@@ -369,8 +363,7 @@ class TestEmailField:
         assert e.value.args[0] == ''
 
     def test_it_enforces_valid_data_type(self):
-        # TODO make this consistent between Py2 & Py3
-        expected_err_msg = 'Value must be of (str|basestring) type.'
+        expected_err_msg = 'Value must be of basestring type.'
         with pytest.raises(ValidationError, match=expected_err_msg):
             Email().clean(True)
 
@@ -662,8 +655,7 @@ class TestURLField:
 
     @pytest.mark.parametrize('value', [23.0, True])
     def test_it_enforces_valid_data_type(self, value):
-        # TODO make this consistent between Py2 & Py3
-        expected_err_msg = 'Value must be of (str|basestring) type.'
+        expected_err_msg = 'Value must be of basestring type.'
         with pytest.raises(ValidationError, match=expected_err_msg):
             URL().clean(value)
 
@@ -704,8 +696,7 @@ class TestRelaxedURLField:
 
     @pytest.mark.parametrize('value', [23.0, True])
     def test_it_enforces_valid_data_type(self, value):
-        # TODO make this consistent between Py2 & Py3
-        expected_err_msg = 'Value must be of (str|basestring) type.'
+        expected_err_msg = 'Value must be of basestring type.'
         with pytest.raises(ValidationError, match=expected_err_msg):
             RelaxedURL().clean(value)
 


### PR DESCRIPTION
Add a compatibility layer to make error message unchanged when we migrate to Python 3.