### PR TITLE
Let `SortedSet` sort by a given key

### DIFF
--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -676,8 +676,14 @@ class Enum(Choices):
 class SortedSet(List):
     """Sorted, unique set of values represented as a list."""
 
+    def __init__(self, field_instance, max_length=None, key=None, **kwargs):
+        super(SortedSet, self).__init__(field_instance, max_length, **kwargs)
+        self.key = key
+
     def clean(self, value):
-        return list(sorted(set(super(SortedSet, self).clean(value))))
+        return list(
+            sorted(set(super(SortedSet, self).clean(value)), key=self.key)
+        )
 
 
 class Schema(object):


### PR DESCRIPTION
Related to Python 3.

We can't have a `SortedSet` without a sorting key when comparing objects anymore, since Python 3 is more strict about comparing and sorting objects without an explicit sorting criteria will raise.