### PR TITLE
Check for ValueError

### DIFF
--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -216,7 +216,7 @@ class DateTime(Regex):
             raise ValidationError(self.regex_message)
         try:
             dt = parser.parse(value)
-        except parser.ParserError:
+        except ValueError:
             raise ValidationError('Could not parse datetime')
         if self.min_date:
             if dt.tzinfo is not None and self.min_date.tzinfo is None:


### PR DESCRIPTION
`ParserError` only appears in `python-dateutil==2.8.1`, and it's a subclass of `ValueError`.

Checking for `ValueError` is the safest option, will work in both versions because `ParserError` subclasses it.