### PR TITLE
Drop unused Tox and old Python versions.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,6 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - test-2.7
-      - test-3.4
       - test-3.5
       - test-3.6
       - test-3.7
@@ -26,16 +24,6 @@ defaults: &defaults
       command: sudo python setup.py test
 
 jobs:
-  test-2.7:
-    <<: *defaults
-    docker:
-    - image: circleci/python:2.7
-    - image: mongo:3
-  test-3.4:
-    <<: *defaults
-    docker:
-    - image: circleci/python:3.4
-    - image: mongo:3
   test-3.5:
     <<: *defaults
     docker:

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ pip-log.txt
 
 # Unit test / coverage reports and cache
 .coverage
-.tox
 .pytest_cache/
 
 #Translations

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,4 @@ test=pytest
 
 [flake8]
 ignore=E501,W503,W504
-exclude=venv,.tox,.eggs,build
+exclude=venv,.eggs,build

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 test=pytest
 
 [flake8]
-ignore=E501,W503,W504
+ignore=E501,W503
 exclude=venv,.eggs,build

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import io
 import re
-import sys
 from setuptools import setup
 
 install_requirements = ['python-dateutil', 'pytz']
@@ -10,9 +9,6 @@ test_requirements = install_requirements + [
     'mongoengine',
     'sqlalchemy',
 ]
-
-if sys.version_info[:2] < (3, 4):
-    test_requirements += ['enum34']
 
 VERSION_FILE = "cleancat/__init__.py"
 with io.open(VERSION_FILE, "rt", encoding="utf8") as f:
@@ -43,10 +39,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,0 @@
-[tox]
-envlist = py27,py34,py35
-
-[testenv]
-deps = -r{toxinidir}/requirements.txt
-commands = python setup.py test


### PR DESCRIPTION
This commit removes Python v2.7 and v3.4 from the testing matrix (they have both reached the EOL by now) and also removes some information related to `tox`, which is no longer used in this project.

Once we merge this, we should bump the version to v1.0.0.