### PR TITLE
Allow declaring a specific blank value on a per-field basis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,6 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - test-2.7
-      - test-3.4
       - test-3.5
       - test-3.6
       - test-3.7
@@ -26,16 +24,6 @@ defaults: &defaults
       command: sudo python setup.py test
 
 jobs:
-  test-2.7:
-    <<: *defaults
-    docker:
-    - image: circleci/python:2.7
-    - image: mongo:3
-  test-3.4:
-    <<: *defaults
-    docker:
-    - image: circleci/python:3.4
-    - image: mongo:3
   test-3.5:
     <<: *defaults
     docker:

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ pip-log.txt
 
 # Unit test / coverage reports and cache
 .coverage
-.tox
 .pytest_cache/
 
 #Translations

--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -7,6 +7,10 @@ import pytz
 from dateutil import parser
 
 
+# Sentinel value which means "pick the default value" when encountered.
+default_sentinel = object()
+
+
 class ValidationError(Exception):
     pass
 
@@ -34,6 +38,7 @@ class Field(object):
         raw_field_name=None,
         mutable=True,
         read_only=False,
+        blank_value=default_sentinel,
     ):
         """
         By default, the field name is derived from the schema model, but in
@@ -48,6 +53,8 @@ class Field(object):
         self.field_name = field_name
         self.raw_field_name = raw_field_name or field_name
         self.read_only = read_only
+        if blank_value is not default_sentinel:
+            self.blank_value = blank_value
 
     def has_value(self, value):
         return value is not None

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,4 @@ test=pytest
 
 [flake8]
 ignore=E501,W503,W504
-exclude=venv,.tox,.eggs,build
+exclude=venv,.eggs,build

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 test=pytest
 
 [flake8]
-ignore=E501,W503,W504
+ignore=E501,W503
 exclude=venv,.eggs,build

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import io
 import re
-import sys
 from setuptools import setup
 
 install_requirements = ['python-dateutil', 'pytz']
@@ -10,9 +9,6 @@ test_requirements = install_requirements + [
     'mongoengine',
     'sqlalchemy',
 ]
-
-if sys.version_info[:2] < (3, 4):
-    test_requirements += ['enum34']
 
 VERSION_FILE = "cleancat/__init__.py"
 with io.open(VERSION_FILE, "rt", encoding="utf8") as f:
@@ -43,10 +39,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -839,11 +839,19 @@ class TestSchema:
     def test_blank_values_for_optional_fields(self):
         class OptionalSchema(Schema):
             text = String(required=False)
+            nullable_text = Bool(required=False, blank_value=None)
             boolean = Bool(required=False)
+            nullable_boolean = Bool(required=False, blank_value=None)
             number = Integer(required=False)
 
         data = OptionalSchema({}).full_clean()
-        assert data == {'text': '', 'boolean': False, 'number': None}
+        assert data == {
+            'text': '',
+            'nullable_text': None,
+            'boolean': False,
+            'nullable_boolean': None,
+            'number': None,
+        }
 
     def test_it_preserves_orig_data_if_no_new_data_given(self):
         class OptionalSchema(Schema):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,0 @@
-[tox]
-envlist = py27,py34,py35
-
-[testenv]
-deps = -r{toxinidir}/requirements.txt
-commands = python setup.py test


### PR DESCRIPTION
This is useful when e.g. you want the blank value for a string or a boolean to be `None` instead of the default `''`/`False`.

Branched off of https://github.com/closeio/cleancat/pull/58. Review the last commit only.