### PR TITLE
Add default key to Enum-based SortedSets

### DIFF
--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -1,6 +1,7 @@
 import datetime
 import inspect
 import re
+from operator import attrgetter
 from uuid import UUID as PythonUUID
 
 import pytz
@@ -670,6 +671,8 @@ class SortedSet(List):
 
     def __init__(self, field_instance, max_length=None, key=None, **kwargs):
         super(SortedSet, self).__init__(field_instance, max_length, **kwargs)
+        if isinstance(field_instance, Enum) and key is None:
+            key = attrgetter('value')
         self.key = key
 
     def clean(self, value):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -504,6 +504,17 @@ class TestSortedSetField:
         )
         assert sorted_set == [ClassWithID(1), ClassWithID(2)]
 
+    def test_it_sorts_enums(self):
+        class MyChoices(enum.Enum):
+            A = 'a'
+            B = 'b'
+            C = 'c'
+
+        sorted_set = SortedSet(Enum(MyChoices)).clean(
+            [MyChoices.C.value, MyChoices.B.value, MyChoices.A.value]
+        )
+        assert sorted_set == [MyChoices.A, MyChoices.B, MyChoices.C]
+
     def test_it_enforces_required_flag(self):
         expected_err_msg = 'This field is required.'
         with pytest.raises(ValidationError, match=expected_err_msg):


### PR DESCRIPTION
Set a default sorting `key` to `SortedSet` when it's based on `Enum` and no `key` is provided, to prevent `.clean()` from failing.