### PR TITLE
Issue 43: Make error message consistent

### DIFF
--- a/cleancat/base.py
+++ b/cleancat/base.py
@@ -70,7 +70,7 @@ class Field:
                 allowed_types_text = " or ".join(allowed_types)
             else:
                 allowed_types_text = self.base_type.__name__
-            err_msg = "Value must be of %s type." % allowed_types_text
+            err_msg = "The value must be of %s type." % allowed_types_text
             raise ValidationError(err_msg)
 
         if not self.has_value(value):
@@ -622,7 +622,7 @@ class Choices(Field):
             choices = {choice.lower(): choice for choice in choices}
 
             if not isinstance(value, str):
-                raise ValidationError("Value needs to be a string.")
+                raise ValidationError("The value needs to be a string.")
 
             if value.lower() not in choices:
                 err_msg = self.format_invalid_choice_msg(value)
@@ -847,7 +847,7 @@ class Schema:
                             )
 
                         if value != old_value:
-                            raise ValidationError("Value cannot be changed.")
+                            raise ValidationError("The value cannot be changed.")
 
                     self.data[field_name] = value
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -44,7 +44,7 @@ class TestField:
         assert IntOrStrField().clean(5) == 5
         assert IntOrStrField().clean("five") == "five"
 
-        expected_err_msg = "Value must be of int or str type."
+        expected_err_msg = "The value must be of int or str type."
         with pytest.raises(ValidationError, match=expected_err_msg):
             assert IntOrStrField().clean(4.5)
 
@@ -77,7 +77,7 @@ class TestStringField:
         assert e.value.args[0] == "default"
 
     def test_it_enforces_valid_data_type(self):
-        expected_err_msg = "Value must be of str type."
+        expected_err_msg = "The value must be of str type."
         with pytest.raises(ValidationError, match=expected_err_msg):
             String().clean(True)
 
@@ -156,7 +156,7 @@ class TestTrimmedStringField:
         assert e.value.args[0] == ""
 
     def test_it_enforces_valid_data_type(self):
-        expected_err_msg = "Value must be of str type."
+        expected_err_msg = "The value must be of str type."
         with pytest.raises(ValidationError, match=expected_err_msg):
             TrimmedString().clean(True)
 
@@ -209,7 +209,7 @@ class TestBoolField:
             Bool().clean(None)
 
     def test_it_enforces_valid_data_type(self):
-        expected_err_msg = "Value must be of bool type."
+        expected_err_msg = "The value must be of bool type."
         with pytest.raises(ValidationError, match=expected_err_msg):
             Bool().clean("")
 
@@ -253,7 +253,7 @@ class TestRegexField:
         assert e.value.args[0] == ""
 
     def test_it_enforces_valid_data_type(self):
-        expected_err_msg = "Value must be of str type."
+        expected_err_msg = "The value must be of str type."
         with pytest.raises(ValidationError, match=expected_err_msg):
             Regex("^[a-z]$").clean(True)
 
@@ -304,7 +304,7 @@ class TestDateTimeField:
         assert e.value.args[0] is None
 
     def test_it_enforces_valid_data_type(self):
-        expected_err_msg = "Value must be of str type."
+        expected_err_msg = "The value must be of str type."
         with pytest.raises(ValidationError, match=expected_err_msg):
             DateTime().clean(True)
 
@@ -369,7 +369,7 @@ class TestEmailField:
         assert e.value.args[0] == ""
 
     def test_it_enforces_valid_data_type(self):
-        expected_err_msg = "Value must be of str type."
+        expected_err_msg = "The value must be of str type."
         with pytest.raises(ValidationError, match=expected_err_msg):
             Email().clean(True)
 
@@ -431,7 +431,7 @@ class TestIntegerField:
 
     @pytest.mark.parametrize("value", ["", "0", 23.0])
     def test_it_enforces_valid_data_type(self, value):
-        expected_err_msg = "Value must be of int type."
+        expected_err_msg = "The value must be of int type."
         with pytest.raises(ValidationError, match=expected_err_msg):
             Integer().clean(value)
 
@@ -445,8 +445,8 @@ class TestListField:
         with pytest.raises(ValidationError) as e:
             List(String(max_length=3)).clean(["a", 2, "c", "long"])
         assert e.value.args[0]["errors"][1] in (
-            "Value must be of basestring type.",
-            "Value must be of str type.",
+            "The value must be of basestring type.",
+            "The value must be of str type.",
         )
         assert e.value.args[0]["errors"][3] == (
             "The value must be no longer than 3 characters."
@@ -540,7 +540,7 @@ class TestSortedSetField:
 
     @pytest.mark.parametrize("value", [23.0, True])
     def test_it_enforces_valid_data_type(self, value):
-        expected_err_msg = "Value must be of list type."
+        expected_err_msg = "The value must be of list type."
         with pytest.raises(ValidationError, match=expected_err_msg):
             SortedSet(String()).clean(value)
 
@@ -708,7 +708,7 @@ class TestURLField:
 
     @pytest.mark.parametrize("value", [23.0, True])
     def test_it_enforces_valid_data_type(self, value):
-        expected_err_msg = "Value must be of str type."
+        expected_err_msg = "The value must be of str type."
         with pytest.raises(ValidationError, match=expected_err_msg):
             URL().clean(value)
 
@@ -749,7 +749,7 @@ class TestRelaxedURLField:
 
     @pytest.mark.parametrize("value", [23.0, True])
     def test_it_enforces_valid_data_type(self, value):
-        expected_err_msg = "Value must be of str type."
+        expected_err_msg = "The value must be of str type."
         with pytest.raises(ValidationError, match=expected_err_msg):
             RelaxedURL().clean(value)
 
@@ -911,7 +911,7 @@ class TestSchema:
                 schema.full_clean()
             assert e.value.args[0] == {
                 "errors": [],
-                "field-errors": {"text": "Value cannot be changed."},
+                "field-errors": {"text": "The value cannot be changed."},
             }
 
     def test_serialization(self):
@@ -1041,7 +1041,7 @@ class TestSchema:
             schema.full_clean()
 
         assert schema.field_errors == {
-            "value_id": "Value must be of int type."
+            "value_id": "The value must be of int type."
         }
 
 


### PR DESCRIPTION
This is a PR to change all error messages starting with "Value ..." to "The value ..."

This request was made back in 2018, and is pretty old. But it's an easy fix, so I thought I'd open up the PR to make this fix.

I will be totally transparent and also mention that I will be sending in my resume to you guys so if you're interested in interviewing me,  keep an eye out for my resume.

If not, feel free to merge my PR anyways. I know hiring is tricky so I totally understand if you're not interested.